### PR TITLE
Changed to bundle Pulp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ lib64/
 parts/
 sdist/
 var/
-wheels/
+# wheels/
 share/python-wheels/
 *.egg-info/
 .installed.cfg

--- a/README.md
+++ b/README.md
@@ -12,24 +12,6 @@ Using mathematical optimization, tris to quads.
   - Select the downloaded ZIP file and press the button "Install Add-on".
   - Check the "Mesh: Tris to Quads Ex".
 
-### install PuLP
-
-This add-on needs [PuLP](https://github.com/coin-or/pulp).
-
-- on macOS
-
-```
-/Applications/Blender.app/Contents/Resources/4.2/python/bin/python3.11 -m pip install pulp
-```
-
-- on Windows
-
-```
-"C:\Program Files\Blender Foundation\Blender 4.2\4.2\python\bin\python" -m pip install pulp
-or
-"C:\Program Files\Blender Foundation\Blender 4.2\4.2\python\Scripts\pip" install pulp
-```
-
 ## Usage
 
 - Select an object.

--- a/__init__.py
+++ b/__init__.py
@@ -4,20 +4,6 @@ import bmesh
 import bpy
 from pulp import PULP_CBC_CMD, LpMaximize, LpProblem, LpVariable, lpSum, value
 
-bl_info = {
-    "name": "Tris to Quads Ex",  # プラグイン名
-    "author": "tsutomu",  # 制作者名
-    "version": (1, 2),  # バージョン
-    "blender": (4, 2, 0),  # 動作可能なBlenderバージョン
-    "support": "TESTING",  # サポートレベル
-    "category": "Mesh",  # カテゴリ名
-    "description": "Tris to quads by mathematical optimization.",  # 説明文
-    "location": "Editmode > Face",  # 場所
-    "warning": "",  # 注意点やバグ情報
-    "doc_url": "https://github.com/SaitoTsutomu/Tris-Quads-Ex",  # ドキュメントURL
-}
-
-
 class CEF_OT_tris_convert_to_quads_ex(bpy.types.Operator):
     """Tris to Quads"""
 

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,0 +1,24 @@
+schema_version = "1.0.0"
+
+id = "tris_to_quads_ex"
+name = "Tris to Quads Ex"
+
+maintainer = "tsutomu"
+version = "1.2.0"
+blender_version_min = "4.2.0"
+
+tags = ["Mesh"]
+
+tagline = "Tris to quads by mathematical optimization"
+
+type = "add-on"
+
+website = "https://github.com/SaitoTsutomu/Tris-Quads-Ex"
+
+wheels = [
+    "./wheels/PuLP-2.9.0-py3-none-any.whl"
+]
+
+license = [
+    "SPDX:Apache-2.0"
+]


### PR DESCRIPTION
Python Wheelsを使って`PuLP`ライブラリをバンドルするようにしました。
また、それに伴って`README.md`の`PuLP`ライブラリのインストールに関する項目を削除し、アドオンの情報を`__init__.py`の`bl_info`ではなく`blender_manifest.toml`で提供するように変更しました。